### PR TITLE
[Fixes] Removed default constructors from KeyVector.

### DIFF
--- a/include/keyvector.h
+++ b/include/keyvector.h
@@ -210,6 +210,16 @@ public:
     }
   }
 
+  KeyVector(KeyVector&)         = delete;
+  KeyVector(const KeyVector&)   = delete;
+  KeyVector(KeyVector&&)        = delete;
+  KeyVector(const KeyVector&&)  = delete;
+  
+  KeyVector& operator=(KeyVector&)        = delete;
+  KeyVector& operator=(const KeyVector&)  = delete;
+  KeyVector& operator=(KeyVector&&)       = delete;
+  KeyVector& operator=(const KeyVector&&) = delete;
+
   // Iterator implementation which is discussed in this blog:
   // https://www.internalpointers.com/post/writing-custom-iterators-modern-cpp
   struct Iterator {

--- a/include/testing/logic_tests.h
+++ b/include/testing/logic_tests.h
@@ -342,7 +342,7 @@ public:
 	}
 
 private:
-	KeyVec testkeyvector;
+	KeyVec& testkeyvector;
 
 	// Eventually change to a vector<string TestName, bool Result> (so we can store multiple failed tests)
 	bool _status = true;


### PR DESCRIPTION
Pretty self-explanatory, it doesn't make sense right now to allow copy-construct, copy-assign, move-construct, or move-assign.

It could be an area of discussion in the future, but for now they are deleted to avoid user errors.