### PR TITLE
[Fixes] Allocator type Pool now uses static_asserts in multiple places

### DIFF
--- a/include/Pool.h
+++ b/include/Pool.h
@@ -21,54 +21,45 @@ template <std::size_t N, std::size_t align>
 class Pool {
 public:
   // Params:
-  // HSetSize - The quantity of unique ID keys this set will hold
-  template<typename Type, typename Index, std::size_t HSetSize>
-  KeyVector<Type, Index, HSetSize>& AddKeyVec() {
-    assert (alignof(Index) < PAGE_SIZE);
-    assert (alignof(Type) < PAGE_SIZE);
-    assert (sizeof(Index) < PAGE_SIZE);
-    assert (sizeof(Type) < PAGE_SIZE);
+  // KeyVecSize - The quantity of unique ID keys this set will hold
+  template<typename Type, typename Index, std::size_t KeyVecSize>
+  KeyVector<Type, Index, KeyVecSize>& AddKeyVec() {
+    static_assert (alignof(Index) <= PAGE_SIZE, "[Pool::AddKeyVec()] Index alignment isn't valid");
+    static_assert (alignof(Type) <= PAGE_SIZE,  "[Pool::AddKeyVec()] Type alignment isn't valid");
+    static_assert (sizeof(Index) <= PAGE_SIZE,  "[Pool::AddKeyVec()] Index size isn't valid");
+    static_assert (sizeof(Type) <= PAGE_SIZE,   "[Pool::AddKeyVec()] Type size isn't valid");
 
     // Testing purposes
-    assert ((sizeof(Index) % alignof(Index)) == 0);
-    assert ((sizeof(Type) % alignof(Type)) == 0);
+    static_assert ((sizeof(Index) % alignof(Index)) == 0);
+    static_assert ((sizeof(Type) % alignof(Type)) == 0);
     
-    constexpr std::size_t HSetAlignment = alignof(KeyVector<Type, Index, HSetSize>);
-    constexpr std::size_t HSetByteSize = sizeof(KeyVector<Type, Index, HSetSize>);
+    constexpr std::size_t KeyVecAlignment = alignof(KeyVector<Type, Index, KeyVecSize>);
+    constexpr std::size_t KeyVecByteSize = sizeof(KeyVector<Type, Index, KeyVecSize>);
 
-    std::cout << "Type Alignment: " << alignof(Type) << '\n';
-    std::cout << "Index Alignment: " << alignof(Index) << '\n';
-    std::cout << std::endl;
-    std::cout << "KeyVec Alignment: " << HSetAlignment << '\n';
-    std::cout << "KeyVec Total ByteSize: " << HSetByteSize << '\n';
 
-    //Testing purposes - shouldn't fail I don't think
-    if (HSetAlignment != std::max({ alignof(Type), alignof(Index), sizeof(std::size_t) })) {
-      std::cout << "[Test failed]: HSetAlignment doesn't == max(alignof(Type), alignof(Index))\n";
-      this->~Pool();
-      abort();
-    }
+    static_assert(KeyVecAlignment == std::max({ alignof(Type), alignof(Index), sizeof(std::size_t) }),
+                  "[Pool::AddKeyVec()] KeyVecAlignment should equal the max alignment of the KeyVector member variables");
 
-    // PAGE_SIZE must be a multiple of HSetAlignment
-    static_assert(PAGE_SIZE % HSetAlignment == 0);
+    // This static_assert is maybe unnecessary
+    static_assert(PAGE_SIZE % KeyVecAlignment == 0);
     
     // Not needed, testing purposes
-    std::size_t Full_Pages_Used = HSetByteSize / PAGE_SIZE;
+    std::size_t Full_Pages_Used = KeyVecByteSize / PAGE_SIZE;
 
     // Crucial value
-    std::size_t Page_Overflow_Remainder = HSetByteSize % PAGE_SIZE;
+    std::size_t Page_Overflow_Remainder = KeyVecByteSize % PAGE_SIZE;
     std::cout << "Full_Pages_Used: " << Full_Pages_Used << '\n';
     std::cout << "Page Overflow Remainder: " << Page_Overflow_Remainder << '\n';
 
     // We need to know how far to move the pointer forward
     std::size_t TotalBytesNeeded;
-    // HSet perfectly aligned with PAGE_SIZE, lucky!
+    // KeyVec object perfectly aligns with the page boundary, lucky!
     if (Page_Overflow_Remainder == 0) {
-      TotalBytesNeeded = HSetByteSize;
+      TotalBytesNeeded = KeyVecByteSize;
     }
-    // HSet fills up part of an extra page. Needs 1 full extra page of space.
+    // KeyVec fills up part of an extra page. Needs 1 full extra page of space.
     else {
-      TotalBytesNeeded = HSetByteSize - Page_Overflow_Remainder + PAGE_SIZE;
+      TotalBytesNeeded = KeyVecByteSize - Page_Overflow_Remainder + PAGE_SIZE;
     }
     std::cout << "TotalBytesNeeded: " << TotalBytesNeeded << '\n';
     std::cout << std::endl;
@@ -82,12 +73,12 @@ public:
       // For Exception Handling Pools it may be a different implementation
       abort();
     }
-    // Enough space exists -> Place HSet finally
+    // Enough space exists -> Place KeyVec finally
     else {
       // Need to convert tracking_ptr into appropriate type -> To use with placement new
-      KeyVector<Type, Index, HSetSize>* ptr_head = reinterpret_cast<KeyVector<Type, Index, HSetSize>*>(_tracking_ptr);
+      KeyVector<Type, Index, KeyVecSize>* ptr_head = reinterpret_cast<KeyVector<Type, Index, KeyVecSize>*>(_tracking_ptr);
 
-      KeyVector<Type, Index, HSetSize>* constructedObject = ::new (ptr_head) KeyVector<Type, Index, HSetSize>;
+      KeyVector<Type, Index, KeyVecSize>* constructedObject = ::new (ptr_head) KeyVector<Type, Index, KeyVecSize>;
 
       _ptr_list.push_back(reinterpret_cast<BaseVec*>(constructedObject));
      
@@ -122,12 +113,12 @@ public:
 
     if (align % PAGE_SIZE != 0) {
       std::cout << "Alignment must be multiple of 4096\n";
-      abort();  // TODO: Change to throws
+      abort();
     }
 
     if (N % align != 0) {
       std::cout << "Size must be multiple of align\n";
-      abort();  // TODO: Change to throws
+      abort();
     }
 
     _lead_ptr = std::aligned_alloc(align, N);
@@ -136,11 +127,10 @@ public:
       // Instead of abort really the whole program should be exited gracefully (cleaning up other memory)
       // Anyway, it works for now. (This is the only memory allocation)
       std::cout << "Bad allocation\n";
-      abort();  // TODO: Change to throws
+      abort();
     }
 
     // Memory is confirmed as allocated
-    // Must be freed. This bool flag ensures a free
     std::cout << "~~~~~~~~~~~~~~~~~ \n";
     std::cout << std::endl;
     std::cout << "New Memory Pool" << '\n';


### PR DESCRIPTION
- Prevents compilation altogether for invalid type/index sizes and alignments.

- **Goal:** The size and alignment for a ```KeyVector``` object should be less than 
```constexpr static std::size_t PAGE_SIZE = 4096 ``` bytes.

This restriction is in place until the effect of such object sizes on the allocator are better understood.